### PR TITLE
Fix an out of bounds error when BigInt is 0

### DIFF
--- a/pickle_writer.go
+++ b/pickle_writer.go
@@ -379,7 +379,7 @@ func (proxy bigIntProxy) WriteTo(w io.Writer) (int, error) {
 
 	var pad []byte
 	var padL int
-	var highBitSet = (raw[0] & 0x80) != 0
+	var highBitSet = (len(raw) > 0 && raw[0] & 0x80 == 0x80)
 
 	if negative && !highBitSet {
 		pad = maxPad

--- a/pickle_writer.go
+++ b/pickle_writer.go
@@ -379,7 +379,7 @@ func (proxy bigIntProxy) WriteTo(w io.Writer) (int, error) {
 
 	var pad []byte
 	var padL int
-	var highBitSet = (len(raw) > 0 && raw[0] & 0x80 == 0x80)
+	var highBitSet = (len(raw) > 0 && (raw[0] & 0x80) == 0x80)
 
 	if negative && !highBitSet {
 		pad = maxPad

--- a/pickle_writer_test.go
+++ b/pickle_writer_test.go
@@ -314,6 +314,9 @@ func TestPickleBigInt(t *testing.T) {
 
 	i.Mul(i, big.NewInt(-1))
 	roundTrip(i, t)
+
+	i = big.NewInt(0)
+	roundTrip(i, t)
 }
 
 func TestPickleTuple(t *testing.T) {


### PR DESCRIPTION
If Pickling a BigInt whose value is 0. the high bit check was panicing on an array out of bounds.  The len of the BigInt was 0.