### PR TITLE
fix uint test on 32-bit archs

### DIFF
--- a/pickle_writer_test.go
+++ b/pickle_writer_test.go
@@ -129,7 +129,7 @@ func TestPickleUint64(t *testing.T) {
 	inAndOut(i, bi, t)
 
 	var ui uint
-	ui = 18446744073709551615
+	ui = ^uint(0)
 	bi.SetUint64(uint64(ui))
 	inAndOut(ui, bi, t)
 }


### PR DESCRIPTION
This PR fixes #10 by making sure the appropriate maximal value for a `uint` on the target architecture is used in the tests. With the 64-bit value hardcoded, this assignment would overflow `uint` on 32-bit architectures, e.g. i386.

After the change:
```
[vagrant@vagrant-debian:hydrogen18/stalecucumber] $ env GOOS=linux GOARCH=386 go test        ± [master] [0]
PASS
ok  	github.com/hydrogen18/stalecucumber	0.007s
[vagrant@vagrant-debian:hydrogen18/stalecucumber] $ env GOOS=linux GOARCH=amd64 go test      ± [master] [0]
PASS
ok  	github.com/hydrogen18/stalecucumber	0.005s
``` 